### PR TITLE
sec: CSPのframe-ancestorsをHTTPヘッダーに移動しform-actionを追加

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,4 +1,5 @@
 /*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co; font-src 'self'; form-action 'self'; frame-ancestors 'none';
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Cross-Origin-Opener-Policy: same-origin

--- a/serve.json
+++ b/serve.json
@@ -3,6 +3,7 @@
     {
       "source": "**/*",
       "headers": [
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co; font-src 'self'; form-action 'self'; frame-ancestors 'none';" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },

--- a/src/app/+html.tsx
+++ b/src/app/+html.tsx
@@ -11,10 +11,10 @@ export default function Root({ children }: PropsWithChildren) {
           name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
-        {/* Issue 1: Content Security Policy */}
+        {/* CSP: frame-ancestors は meta タグでは無効なため _headers で設定 */}
         <meta
           httpEquiv="Content-Security-Policy"
-          content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co; font-src 'self'; frame-ancestors 'none';"
+          content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co; font-src 'self'; form-action 'self';"
         />
         <ScrollViewStyleReset />
       </head>


### PR DESCRIPTION
- frame-ancestors はメタタグでは無効なため _headers/serve.json に移動
- form-action 'self' を追加（default-src にフォールバックしないため）
- _headers に CSP ヘッダーを追加し非HTMLファイルにも適用